### PR TITLE
Make sure we post UTF-8

### DIFF
--- a/prestapyt/prestapyt.py
+++ b/prestapyt/prestapyt.py
@@ -255,7 +255,7 @@ class PrestaShopWebService(object):
         @return: an ElementTree of the response from the web service
         """
         headers = {'Content-Type': 'application/x-www-form-urlencoded'}
-        return self._parse(self._execute(url, 'POST', body=urllib.urlencode({'xml': xml}), add_headers=headers)[2])
+        return self._parse(self._execute(url, 'POST', body=urllib.urlencode({'xml': xml.encode('utf-8')}), add_headers=headers)[2])
 
     def search(self, resource, options=None):
         """


### PR DESCRIPTION
Sometimes the XML is not in correct UTF-8 encoding. Similar problem on
SO:
http://stackoverflow.com/questions/787935/python-interface-to-paypal-url
lib-urlencode-non-ascii-characters-failing
