### PR TITLE
Disable Httplib2 server authorization type requests for each Prestashop API request.

### DIFF
--- a/prestapyt/prestapyt.py
+++ b/prestapyt/prestapyt.py
@@ -177,6 +177,8 @@ class PrestaShopWebService(object):
             self.http_client = httplib2.Http(**self.client_args)
             # Prestashop use the key as username without password
             self.http_client.add_credentials(self._api_key, False)
+            if hasattr(self.http_client, "set_auth_type"):
+                self.http_client.set_auth_type("basic")
             self.http_client.follow_all_redirects = True
 
         if self.debug:


### PR DESCRIPTION
Added additional flag `auth_type` in the `Http` class of the Httplib2 library and call `set_auth_type("basic")` in the Prestapyt library if the Httplib2 has the method `set_auth_type`.
This flag sets server authorization type and disables automatic detection for each request because I send 50000 requests and I don't need authorization type detection requests in the same amount. Each request has unique URI - this is the REST API requests. Therefore I set server authorization type directly with the call `self.http_client.set_auth_type("basic")`.
Httplib2 pull request: https://github.com/uggedal/httplib2/pull/1
