### PR TITLE
[FIX] prestapyt: Fix parse error returned from PrestaShop server.

### DIFF
--- a/prestapyt/prestapyt.py
+++ b/prestapyt/prestapyt.py
@@ -126,6 +126,8 @@ class PrestaShopWebService(object):
                              .get('errors', {})
                              .get('error', {})
                              )
+            if isinstance(error_content, list):
+                error_content = error_content[0]
         return (error_content.get('code'), error_content.get('message'))
 
     def _check_status_code(self, status_code, content):


### PR DESCRIPTION
Hi @guewen this is a minor fix. When a message error is returned from PS server the message key is a list.
Can you review the fix? 

this is an example of error message:
{'prestashop': {'errors': {'error': [{'message': "[SQL Error] ....}]}}}
Thanks
cc @Tecnativa @pedrobaeza 