### PR TITLE
Bump the version to 0.9.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,9 @@ If you do not have setuptools, download prestapyt as a .tar.gz or .zip from
 
     python setup.py install
 
+In order to always be uptodate, the best way is to use pip from this repo with the following command :
+
+    pip install --ignore-installed git+https://github.com/prestapyt/prestapyt.git@master
 
 ## Usage
 

--- a/prestapyt/version.py
+++ b/prestapyt/version.py
@@ -1,2 +1,2 @@
 __author__ = "Guewen Baconnier <guewen.baconnier@gmail.com>"
-__version__ = "0.9.0"
+__version__ = "0.9.1"


### PR DESCRIPTION
This PR https://github.com/prestapyt/prestapyt/pull/51 add some great functionalities.

Yet the version hasn't been upgraded so that pip install doesn't inform us about the correct and latest version available
