### PR TITLE
Add support for JSON format in API

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
     include_package_data = True,
 
     # Package dependencies.
-    install_requires = ['requests','future'],
+    install_requires = ['requests','future', 'dicttoxml'],
 
     # Metadata for PyPI.
     author = 'Guewen Baconnier',


### PR DESCRIPTION
The Webservice of Prestashop support JSON format in GET methods https://devdocs.prestashop.com/1.7/development/webservice/#using-json-instead-of-xml

The goal of the PR is to support JSON format when we use **prestapyt**, for all the operations.

Use:

```python
prestashop = PrestaShopWebService('http://localhost/api', 'KEY', json=True)
address = prestashop.get('addresses', options={'schema': 'blank'}

address['address']['alias'] = 'Alias of the address'
address['address']['address1'] = 'Gran Via, 12'
address['address']['lastname'] = 'Piera'
address['address']['firstname'] = 'Oriol'
address['address']['city'] = 'Barcelona'
address['address']['id_country'] = '1'

prestashop.add('addresses', address)
```