### PR TITLE
authorized to use the Webservice key in parameter

### DIFF
--- a/prestapyt/prestapyt.py
+++ b/prestapyt/prestapyt.py
@@ -293,7 +293,7 @@ class PrestaShopWebService(object):
                 'Parameters must be a instance of dict'
             )
         supported = (
-            'filter', 'display', 'sort',
+            'filter', 'display', 'sort','ws_key',
             'limit', 'schema', 'date', 'id_shop', 'id_group_shop',
         )
         # filter[firstname] (as e.g.) is allowed


### PR DESCRIPTION
On some servers (such as OVH.com), the key authentication mechanism does not work if the key is passed in the header, but the key must be placed in the parameters with the value (ws_key).

With this tiny modification, we can call the webservice like this : 
`product = prestashop.get('products/22',options={'ws_key':'EFVEAFOLBH1ULF7AP0529ZFQE7XLP9T'})`

At first I was thinking of adding some configuration value to the creation of PrestaShopWebService class (eg authorized_by_parameter = true). But finally authorizing the additional parameter seems sufficient to me.