### PR TITLE
fix: python3.9 error fix of deprecated getchildren

### DIFF
--- a/prestapyt/xml2dict.py
+++ b/prestapyt/xml2dict.py
@@ -34,7 +34,7 @@ def _parse_node(node):
 
     #Save childrens
     has_child = False
-    for child in node.getchildren():
+    for child in list(node):
         has_child = True
         ctag = child.tag
         ctree = _parse_node(child)


### PR DESCRIPTION
Hey, as stated here 
https://docs.python.org/2/library/xml.etree.elementtree.html#element-objects 

getchildren() is deprecated and in python 3.9 it throws an error which makes library crashing. 