### PR TITLE
[FIX] Fixed deprecated warnings. Improved max compatible version

### DIFF
--- a/prestapyt/dict2xml.py
+++ b/prestapyt/dict2xml.py
@@ -12,8 +12,13 @@
 
 from __future__ import unicode_literals
 from xml.dom.minidom import getDOMImplementation
-from past.builtins import basestring
 from builtins import str
+
+# past.builtins generates deprecated warning (import imp)
+try:
+    from __builtin__ import basestring
+except ImportError:
+    from past.types import basestring
 
 
 def _process(doc, tag, tag_value):

--- a/prestapyt/prestapyt.py
+++ b/prestapyt/prestapyt.py
@@ -20,8 +20,12 @@ from which I also inspired my library.
 Questions, comments? guewen.baconnier@gmail.com
 """
 
-from future.standard_library import install_aliases
-install_aliases()
+# install_aliases() makes sense only on python 2.x
+# On Python 3.x it generates deprecated warning (import imp)
+from future.utils import PY2
+if PY2:
+    from future.standard_library import install_aliases
+    install_aliases()
 
 from urllib.parse import urlencode
 
@@ -86,7 +90,8 @@ class PrestaShopWebService(object):
     """Interact with the PrestaShop WebService API, use XML for messages."""
 
     MIN_COMPATIBLE_VERSION = '1.4.0.17'
-    MAX_COMPATIBLE_VERSION = '1.7.5.2'
+    # 4th version number is to avoid constant version changes
+    MAX_COMPATIBLE_VERSION = '1.7.8.999'
 
     def __init__(self, api_url, api_key, debug=False, session=None,
                  verbose=False):


### PR DESCRIPTION
When working with the library, depricate warnings regularly appear:
/Users/okuryan/Development/15.0/venv/lib/python3.8/site-packages/future/standard_library/init.py:65: DeprecationWarning: the imp module is deprecated in favour of importlib; see the module's documentation for alternative uses

First one generated by the method install_aliases(). It make sense only on Python 3.xx because it monkey-patches the standard library in Python 2.xx to provide aliases for better Python 3.xx compatibility

Second one generated by past.builtins, becuse it imports past.builtins.misc module that imports imp

Also I suggest setting the lower digit version to 99. This will help to avoid constantly changing this value when a new version of PrestaShop is released
