### PR TITLE
Allow to send custom headers in Session:

### DIFF
--- a/prestapyt/dict2xml.py
+++ b/prestapyt/dict2xml.py
@@ -12,8 +12,13 @@
 
 from __future__ import unicode_literals
 from xml.dom.minidom import getDOMImplementation
-from past.builtins import basestring
 from builtins import str
+
+# past.builtins generates deprecated warning (import imp)
+try:
+    from __builtin__ import basestring
+except ImportError:
+    from past.types import basestring
 
 
 def _process(doc, tag, tag_value):

--- a/prestapyt/prestapyt.py
+++ b/prestapyt/prestapyt.py
@@ -94,7 +94,7 @@ class PrestaShopWebService(object):
     MAX_COMPATIBLE_VERSION = '1.7.8.999'
 
     def __init__(self, api_url, api_key, debug=False, session=None,
-                 verbose=False):
+                 verbose=False, custom_headers=None):
         """
         Create an instance of PrestashopWebService.
 
@@ -143,6 +143,8 @@ class PrestaShopWebService(object):
 
         if session is None:
             self.client = requests.Session()
+            if custom_headers:
+                self.client.headers.update(custom_headers)
         else:
             self.client = session
 

--- a/prestapyt/prestapyt.py
+++ b/prestapyt/prestapyt.py
@@ -20,8 +20,12 @@ from which I also inspired my library.
 Questions, comments? guewen.baconnier@gmail.com
 """
 
-from future.standard_library import install_aliases
-install_aliases()
+# install_aliases() makes sense only on python 2.x
+# On Python 3.x it generates deprecated warning (import imp)
+from future.utils import PY2
+if PY2:
+    from future.standard_library import install_aliases
+    install_aliases()
 
 from urllib.parse import urlencode
 
@@ -86,7 +90,8 @@ class PrestaShopWebService(object):
     """Interact with the PrestaShop WebService API, use XML for messages."""
 
     MIN_COMPATIBLE_VERSION = '1.4.0.17'
-    MAX_COMPATIBLE_VERSION = '1.7.5.2'
+    # 4th version number is to avoid constant version changes
+    MAX_COMPATIBLE_VERSION = '1.7.8.999'
 
     def __init__(self, api_url, api_key, debug=False, session=None,
                  verbose=False):

--- a/prestapyt/version.py
+++ b/prestapyt/version.py
@@ -1,5 +1,8 @@
-from importlib.metadata import version, PackageNotFoundError
-
+try:
+    from importlib.metadata import version, PackageNotFoundError
+except:
+    # for python < 3.8
+    from importlib_metadata import version, PackageNotFoundError
 
 __author__ = "Guewen Baconnier <guewen.baconnier@gmail.com>"
 

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
     include_package_data = True,
 
     # Package dependencies.
-    install_requires = ['requests','future'],
+    install_requires = ['requests', 'future', 'importlib-metadata; python_version < "3.8"'],
     setup_requires=[
         'setuptools_scm',
     ],


### PR DESCRIPTION
- To work with Xdebug on your local instance of Prestashop you must include a Cookie in the headers to identify the IDE that will interpret the breakpoints.
- With this change it is allowed to perform this operation when initializing the PrestaShopWebService class