### PR TITLE
Add headers on all requests

### DIFF
--- a/prestapyt/prestapyt.py
+++ b/prestapyt/prestapyt.py
@@ -93,8 +93,8 @@ class PrestaShopWebService(object):
     # 4th version number is to avoid constant version changes
     MAX_COMPATIBLE_VERSION = '1.7.8.999'
 
-    def __init__(self, api_url, api_key, debug=False, session=None,
-                 verbose=False):
+    def __init__(self, api_url, api_key, headers=False, debug=False,
+                 session=None, verbose=False):
         """
         Create an instance of PrestashopWebService.
 

--- a/prestapyt/prestapyt.py
+++ b/prestapyt/prestapyt.py
@@ -109,6 +109,12 @@ class PrestaShopWebService(object):
         except PrestaShopWebServiceError as err:
             ...
 
+        If headers is set, this means that you want to put some headers
+        on all requests sent by Prestapyt. For example, you could want
+        to change the User-Agent for all requests. You can do that
+        by adding headers={'User-Agent': 'your_user_agent'} on this init
+        method.
+
         When verbose mode is activated, you might need to activate the
         debug logging for the logger "requests.packages.urllib3"::
 
@@ -120,6 +126,7 @@ class PrestaShopWebService(object):
 
         :param api_url: Root URL for the shop
         :param api_key: Authentification key
+        :param headers: Additionnal headers on all requests
         :param debug: activate PrestaShop's webservice debug mode
         :param session: pass a custom requests Session
         :param verbose: activate logging of the requests/responses (but no
@@ -148,6 +155,9 @@ class PrestaShopWebService(object):
 
         if not self.client.auth:
             self.client.auth = (api_key, '')
+
+        if self.headers:
+            self.client.headers = headers
 
     def _parse_error(self, xml_content):
         """Take the XML content as string and extract the PrestaShop error.


### PR DESCRIPTION
Some Prestashop environments disallow WebServices if the User-Agent is not defined or if the User-Agent is an User-Agent of a different service (web browser, phone...).

To add a specific User-Agent (consistent with RFC 7231 (https://www.rfc-editor.org/rfc/rfc7231#section-5.5.3)), we have to pass explicitly the User-Agent in the headers of all requests.

This merge request uses the headers of the requests.Session object to do that.

To add different headers, just put data in the `headers` parameters of the constructor and that's it.