### PR TITLE
multipart/mime: apply RFC-compliant boundary

### DIFF
--- a/prestapyt/prestapyt.py
+++ b/prestapyt/prestapyt.py
@@ -32,6 +32,7 @@ from urllib.parse import urlencode
 import warnings
 import requests
 import mimetypes
+import random
 
 from . import xml2dict
 from . import dict2xml
@@ -502,7 +503,7 @@ class PrestaShopWebService(object):
             elements for data to be uploaded as files.
         :return: headers and body.
         """
-        BOUNDARY = '----------ThIs_Is_tHe_bouNdaRY_$'
+        BOUNDARY = "--" + str(int(random.random() * 1e10))
         CRLF = b'\r\n'
         L = []
         for (key, filename, value) in files:


### PR DESCRIPTION
ModSecurity blocks requests due to an invalid request body.

The chosen boundary for multipart/mime requests does not comply with RFC 2046.

This commit changes this.

~~~json
{
  "request": {
    "request_line": "POST //api//images/products/18413 HTTP/1.1",
    "headers": {
      "Host": "www.example.com",
      "User-Agent": "python-requests/2.21.0",
      "Accept-Encoding": "gzip, deflate",
      "Accept": "*/*",
      "Connection": "keep-alive",
      "Content-Type": "multipart/form-data; boundary=----------ThIs_Is_tHe_bouNdaRY_$",
      "Content-Length": "84156",
      "Authorization": "Basic xxxx"
    },
    "fake_body": ""
  },
  "response": {
    "protocol": "HTTP/1.1",
    "status": 400,
    "headers": {
      "Content-Length": "266",
      "Connection": "close",
      "Content-Type": "text/html; charset=iso-8859-1"
    },
    "body": "<!DOCTYPE HTML PUBLIC \"-//W3C//DTD HTML 4.01//EN\" \"http://www.w3.org/TR/html4/strict.dtd\">\n<html><head>\n<title>400 Bad Request</title>\n</head><body>\n<h1>Bad Request</h1>\n<p>Your browser sent a request that this server could not understand.<br />\n</p>\n</body></html>\n"
  },
  "audit_data": {
    "messages": [
      "Multipart parsing error (init): Multipart: Invalid boundary in C-T (characters).",
      "Access denied with code 400 (phase 2). Match of \"eq 0\" against \"MULTIPART_STRICT_ERROR\" required. [file \"/etc/modsecurity/modsecurity.conf\"] [line \"93\"] [id \"200003\"] [msg \"Multipart request body failed strict validation: PE 1, BQ 0, BW 0, DB 0, DA 0, HF 0, LF 0, SM 0, IQ 0, IP 0, IH 0, FL 0\"]"
    ],
    "error_messages": [
      "[file \"apache2_util.c\"] [line 275] [level 3] [client 2a02:74a0:a008:xxxx] ModSecurity: Multipart parsing error (init): Multipart: Invalid boundary in C-T (characters). [hostname \"www.example.com\"] [uri \"/api/images/products/18413\"] [unique_id \"ab0hguU2n3IdW3PBPBKE0wAAAFc\"]",
      "[file \"apache2_util.c\"] [line 275] [level 3] [client 2a02:74a0:a008:xxxx] ModSecurity: Access denied with code 400 (phase 2). Match of \"eq 0\" against \"MULTIPART_STRICT_ERROR\" required. [file \"/etc/modsecurity/modsecurity.conf\"] [line \"93\"] [id \"200003\"] [msg \"Multipart request body failed strict validation: PE 1, BQ 0, BW 0, DB 0, DA 0, HF 0, LF 0, SM 0, IQ 0, IP 0, IH 0, FL 0\"] [hostname \"www.example.com\"] [uri \"/api/images/products/18413\"] [unique_id \"ab0hguU2n3IdW3PBPBKE0wAAAFc\"]"
    ],
    "action": {
      "intercepted": true,
      "phase": 2,
      "message": "Match of \"eq 0\" against \"MULTIPART_STRICT_ERROR\" required."
    },
~~~

Further information:

- https://malware.expert/howto/multipart-invalid-boundary-in-c-t-characters/